### PR TITLE
Add Qubo puzzle web game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Qubo
+
+Qubo is a quantum-inspired logic puzzle. Choose a board size (6×6 or 12×12) and difficulty, then fill the grid with `0`, `1`, and `ψ` while satisfying quantum-style rules:
+
+- Each row and column must contain an equal number of `0`, `1`, and `ψ` values.
+- No three identical symbols may appear consecutively.
+- Rows and columns must be unique.
+- Sequences of three different symbols (like `0-1-ψ`) are not allowed.
+
+Use the controls to pick the board size and difficulty (easy/medium/hard) and click **New Game** for a fresh, randomly generated puzzle. The generator backtracks to ensure every puzzle has a unique solution. The layout automatically scales to fit the browser window.
+
+Open `index.html` in a browser or enable GitHub Pages to play at `https://<username>.github.io/Qubo/`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Qubo Puzzle</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <h1>Qubo</h1>
+    <div id="controls">
+      <label>
+        Size
+        <select id="size-select">
+          <option value="6">6×6</option>
+          <option value="12">12×12</option>
+        </select>
+      </label>
+      <label>
+        Difficulty
+        <select id="difficulty-select">
+          <option value="easy">Easy</option>
+          <option value="medium">Medium</option>
+          <option value="hard">Hard</option>
+        </select>
+      </label>
+      <button id="new-game">New Game</button>
+    </div>
+    <div id="board-container">
+      <table id="board"></table>
+      <svg id="links"></svg>
+    </div>
+    <div id="message"></div>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,226 @@
+const STATES = ["", "0", "1", "ψ"];
+const REAL_STATES = ["0", "1", "ψ"];
+
+let SIZE = 6;
+let board = [];
+let solution = [];
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function generateSolution(size) {
+  const max = size / 3;
+  const grid = Array.from({ length: size }, () => Array(size).fill(""));
+
+  function backtrack(idx = 0) {
+    if (idx === size * size) return true;
+    const r = Math.floor(idx / size);
+    const c = idx % size;
+    const vals = shuffle([...REAL_STATES]);
+    for (const v of vals) {
+      grid[r][c] = v;
+      if (isValid(grid, r, c, max) && backtrack(idx + 1)) return true;
+      grid[r][c] = "";
+    }
+    return false;
+  }
+
+  backtrack();
+  return grid;
+}
+
+function isValid(grid, r, c, max) {
+  const size = grid.length;
+
+  const rowCounts = { 0: 0, 1: 0, ψ: 0 };
+  for (let j = 0; j < size; j++) {
+    const v = grid[r][j];
+    if (v) {
+      rowCounts[v]++;
+      if (rowCounts[v] > max) return false;
+    }
+  }
+
+  const colCounts = { 0: 0, 1: 0, ψ: 0 };
+  for (let i = 0; i < size; i++) {
+    const v = grid[i][c];
+    if (v) {
+      colCounts[v]++;
+      if (colCounts[v] > max) return false;
+    }
+  }
+
+  for (let j = Math.max(0, c - 2); j <= c && j + 2 < size; j++) {
+    const a = grid[r][j];
+    const b = grid[r][j + 1];
+    const d = grid[r][j + 2];
+    if (a && b && d) {
+      if (a === b && a === d) return false;
+      if (a !== b && b !== d && a !== d) return false;
+    }
+  }
+
+  for (let i = Math.max(0, r - 2); i <= r && i + 2 < size; i++) {
+    const a = grid[i][c];
+    const b = grid[i + 1][c];
+    const d = grid[i + 2][c];
+    if (a && b && d) {
+      if (a === b && a === d) return false;
+      if (a !== b && b !== d && a !== d) return false;
+    }
+  }
+
+  const row = grid[r];
+  if (!row.includes("")) {
+    const rowStr = row.join("");
+    for (let i = 0; i < size; i++) {
+      if (i !== r && grid[i].join("") === rowStr) return false;
+    }
+  }
+
+  const col = [];
+  for (let i = 0; i < size; i++) col.push(grid[i][c]);
+  if (!col.includes("")) {
+    const colStr = col.join("");
+    for (let j = 0; j < size; j++) {
+      if (j !== c) {
+        const other = [];
+        for (let i = 0; i < size; i++) other.push(grid[i][j]);
+        if (!other.includes("") && other.join("") === colStr) return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function cloneBoard(b) {
+  return b.map((row) => row.slice());
+}
+
+function countSolutions(b, limit = 2) {
+  const size = b.length;
+  const max = size / 3;
+
+  function search(idx = 0) {
+    if (idx === size * size) return 1;
+    const r = Math.floor(idx / size);
+    const c = idx % size;
+    if (b[r][c]) return search(idx + 1);
+    let total = 0;
+    for (const v of REAL_STATES) {
+      b[r][c] = v;
+      if (isValid(b, r, c, max)) {
+        total += search(idx + 1);
+        if (total >= limit) break;
+      }
+      b[r][c] = "";
+    }
+    return total;
+  }
+
+  return search();
+}
+
+function hasUniqueSolution(p) {
+  return countSolutions(cloneBoard(p), 2) === 1;
+}
+
+function generatePuzzle(size, diff) {
+  const sol = generateSolution(size);
+  const puzz = cloneBoard(sol);
+  const total = size * size;
+  const targets = {
+    easy: Math.floor(total * 0.3),
+    medium: Math.floor(total * 0.5),
+    hard: Math.floor(total * 0.7),
+  };
+  const target = targets[diff] || targets.easy;
+  const cells = [];
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) cells.push([r, c]);
+  }
+  shuffle(cells);
+  let removed = 0;
+  for (const [r, c] of cells) {
+    const tmp = puzz[r][c];
+    puzz[r][c] = "";
+    if (hasUniqueSolution(puzz)) {
+      removed++;
+      if (removed >= target) break;
+    } else {
+      puzz[r][c] = tmp;
+    }
+  }
+  return { puzzle: puzz, solution: sol };
+}
+
+function renderBoard() {
+  const table = document.getElementById("board");
+  table.innerHTML = "";
+  document.documentElement.style.setProperty("--size", SIZE);
+  for (let r = 0; r < SIZE; r++) {
+    const tr = document.createElement("tr");
+    for (let c = 0; c < SIZE; c++) {
+      const td = document.createElement("td");
+      td.classList.add("cell");
+      td.dataset.row = r;
+      td.dataset.col = c;
+      const val = board[r][c];
+      if (val) {
+        td.textContent = val;
+        td.classList.add("prefill", `state-${val}`);
+      } else {
+        td.addEventListener("click", handleCellClick);
+      }
+      tr.appendChild(td);
+    }
+    table.appendChild(tr);
+  }
+}
+
+function handleCellClick(e) {
+  const td = e.target;
+  const r = parseInt(td.dataset.row, 10);
+  const c = parseInt(td.dataset.col, 10);
+  const idx = (STATES.indexOf(board[r][c] || "") + 1) % STATES.length;
+  const val = STATES[idx];
+  board[r][c] = val;
+  td.textContent = val;
+  td.className = "cell";
+  if (val) td.classList.add(`state-${val}`);
+  checkSolution();
+}
+
+function checkSolution() {
+  const msg = document.getElementById("message");
+  if (board.flat().includes("")) {
+    msg.textContent = "";
+    return;
+  }
+  if (board.flat().join("") === solution.flat().join("")) {
+    msg.textContent = "Puzzle solved!";
+  } else {
+    msg.textContent = "Rules violated!";
+  }
+}
+
+function newGame() {
+  SIZE = parseInt(document.getElementById("size-select").value, 10);
+  const diff = document.getElementById("difficulty-select").value;
+  const { puzzle, solution: sol } = generatePuzzle(SIZE, diff);
+  board = puzzle;
+  solution = sol;
+  renderBoard();
+  document.getElementById("message").textContent = "";
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.getElementById("new-game").addEventListener("click", newGame);
+  newGame();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,83 @@
+body {
+  font-family: sans-serif;
+  text-align: center;
+}
+
+#controls {
+  margin-bottom: 1rem;
+}
+
+#board-container {
+  position: relative;
+  display: inline-block;
+  width: min(90vmin, 600px);
+  height: min(90vmin, 600px);
+}
+
+#board {
+  border-collapse: collapse;
+  margin: 0 auto;
+  width: 100%;
+  height: 100%;
+}
+
+:root {
+  --size: 6;
+}
+
+.cell {
+  width: calc(100% / var(--size));
+  height: calc(100% / var(--size));
+  border: 1px solid #ccc;
+  font-size: calc(60vmin / var(--size));
+  cursor: pointer;
+  text-align: center;
+  vertical-align: middle;
+}
+
+.cell.prefill {
+  background: #eee;
+  cursor: default;
+}
+
+.state-0 {
+  color: blue;
+}
+
+.state-1 {
+  color: red;
+}
+
+.state-ψ {
+  color: purple;
+}
+
+#links {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.entangled {
+  stroke: #888;
+  stroke-width: 2;
+  animation: glow 1s linear infinite;
+}
+
+@keyframes glow {
+  0% {
+    stroke: #888;
+  }
+  50% {
+    stroke: #fff;
+  }
+  100% {
+    stroke: #888;
+  }
+}
+
+#message {
+  margin-top: 1rem;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- Generate Qubo boards randomly with backtracking to ensure a single solution and provide easy/medium/hard modes
- Allow selecting 6×6 or 12×12 boards and scale the layout to any screen
- Document new controls and rules

## Testing
- `npx prettier --check index.html style.css script.js README.md`
- `npm test` *(fails: Could not read package.json)*

------